### PR TITLE
Fixed double callback call on .values and .get

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -45,10 +45,10 @@ var util          = require('util')
  * a single registry value record
  */
 function RegistryItem (host, hive, key, name, type, value) {
-  
+
   if (!(this instanceof RegistryItem))
     return new RegistryItem(host, hive, key, name, type, value);
-  
+
   /* private members */
   var _host = host    // hostname
   ,   _hive = hive    // registry hive
@@ -56,7 +56,7 @@ function RegistryItem (host, hive, key, name, type, value) {
   ,   _name = name    // property name
   ,   _type = type    // property type
   ,   _value = value  // property value
-  
+
   /* getters/setters */
   this.__defineGetter__('host', function () { return _host; });
   this.__defineGetter__('hive', function () { return _hive; });
@@ -64,7 +64,7 @@ function RegistryItem (host, hive, key, name, type, value) {
   this.__defineGetter__('name', function () { return _name; });
   this.__defineGetter__('type', function () { return _type; });
   this.__defineGetter__('value', function () { return _value; });
-  
+
   Object.freeze(this);
 }
 
@@ -80,16 +80,16 @@ Object.freeze(RegistryItem.prototype);
  * a registry object, which provides access to a single Registry key
  */
 function Registry (options) {
-  
+
   if (!(this instanceof Registry))
     return new Registry(options);
-  
+
   /* private members */
   var _options = options || {}
   ,   _host = '' + (_options.host || '')    // hostname
   ,   _hive = '' + (_options.hive || HKLM)  // registry hive
   ,   _key  = '' + (_options.key  || '')    // registry key
-  
+
   /* getters/setters */
   this.__defineGetter__('host', function () { return _host; });
   this.__defineGetter__('hive', function () { return _hive; });
@@ -103,14 +103,14 @@ function Registry (options) {
       key:  (i == -1)?'':_key.substring(0, i)
     });
   });
-  
+
   // validate options...
   if (HIVES.indexOf(_hive) == -1)
     throw new Error('illegal hive specified.');
-  
+
   if (!KEY_PATTERN.test(_key))
     throw new Error('illegal key specified.');
-  
+
   Object.freeze(this);
 }
 
@@ -190,10 +190,10 @@ Registry.REG_TYPES = REG_TYPES;
  * retrieve all values from this registry key
  */
 Registry.prototype.values = function values (cb) {
-  
+
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
+
   var args = [ 'QUERY', this.path ]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
@@ -202,55 +202,53 @@ Registry.prototype.values = function values (cb) {
       })
   ,   buffer = ''
   ,   self = this
-  
+
   proc.on('close', function (code) {
+
     if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code), null);
+    } else {
+      var items = []
+      ,   result = []
+      ,   lines = buffer.split('\n')
+      ,   lineNumber = 0
+
+      for (var line in lines) {
+        lines[line] = lines[line].trim();
+        if (lines[line].length > 0) {
+          log(lines[line]);
+          if (lineNumber != 0) {
+            items.push(lines[line]);
+          }
+          ++lineNumber;
+        }
+      }
+
+      for (var item in items) {
+
+        var match = ITEM_PATTERN.exec(items[item])
+        ,   name
+        ,   type
+        ,   value
+
+        if (match) {
+          name = match[1].trim();
+          type = match[2].trim();
+          value = match[3];
+          result.push(new RegistryItem(self.host, self.hive, self.key, name, type, value));
+        }
+      }
+
+      cb(null, result);
+
     }
   });
-  
+
   proc.stdout.on('data', function (data) {
     buffer += data.toString();
   });
-  
-  proc.stdout.on('end', function () {
-  
-    var items = []
-    ,   result = []
-    ,   lines = buffer.split('\n')
-    ,   lineNumber = 0
-    
-    for (var line in lines) {
-      lines[line] = lines[line].trim();
-      if (lines[line].length > 0) {
-        log(lines[line]);
-        if (lineNumber != 0) {
-          items.push(lines[line]);
-        }
-        ++lineNumber;
-      }
-    }  
-    
-    for (var item in items) {
-      
-      var match = ITEM_PATTERN.exec(items[item])
-      ,   name
-      ,   type
-      ,   value
-      
-      if (match) {
-        name = match[1].trim();
-        type = match[2].trim();
-        value = match[3];
-        result.push(new RegistryItem(self.host, self.hive, self.key, name, type, value));
-      }
-    }
-    
-    cb(null, result);
-    
-  });
-  
+
   return this;
 };
 
@@ -258,10 +256,10 @@ Registry.prototype.values = function values (cb) {
  * retrieve all subkeys from this registry key
  */
 Registry.prototype.keys = function keys (cb) {
-  
+
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
+
   var args = [ 'QUERY', this.path ]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
@@ -270,38 +268,38 @@ Registry.prototype.keys = function keys (cb) {
       })
   ,   buffer = ''
   ,   self = this
-  
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code), null);
     }
   });
-  
+
   proc.stdout.on('data', function (data) {
     buffer += data.toString();
   });
-  
+
   proc.stdout.on('end', function () {
-  
+
     var items = []
     ,   result = []
     ,   lines = buffer.split('\n')
-    
+
     for (var line in lines) {
       lines[line] = lines[line].trim();
       if (lines[line].length > 0) {
         log(lines[line]);
         items.push(lines[line]);
       }
-    }  
-    
+    }
+
     for (var item in items) {
-      
+
       var match = PATH_PATTERN.exec(items[item])
       ,   hive
       ,   key
-      
+
       if (match) {
         hive = match[1];
         key  = match[2];
@@ -314,11 +312,11 @@ Registry.prototype.keys = function keys (cb) {
         }
       }
     }
-    
+
     cb(null, result);
-    
+
   });
-  
+
   return this;
 };
 
@@ -326,10 +324,10 @@ Registry.prototype.keys = function keys (cb) {
  * retrieve a named value from this registry key
  */
 Registry.prototype.get = function get (name, cb) {
-  
+
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
+
   var args = [ 'QUERY', this.path, '/v', name ]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
@@ -338,53 +336,49 @@ Registry.prototype.get = function get (name, cb) {
       })
   ,   buffer = ''
   ,   self = this
-  
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code), null);
+    } else {
+      var items = []
+      ,   result = null
+      ,   lines = buffer.split('\n')
+      ,   lineNumber = 0
+
+      for (var line in lines) {
+        lines[line] = lines[line].trim();
+        if (lines[line].length > 0) {
+          log(lines[line]);
+          if (lineNumber != 0) {
+             items.push(lines[line]);
+          }
+          ++lineNumber;
+        }
+      }
+
+      var item = items[0] || ''
+      ,   match = ITEM_PATTERN.exec(item)
+      ,   name
+      ,   type
+      ,   value
+
+      if (match) {
+        name = match[1].trim();
+        type = match[2].trim();
+        value = match[3];
+        result = new RegistryItem(self.host, self.hive, self.key, name, type, value);
+      }
+
+      cb(null, result);
     }
   });
-  
+
   proc.stdout.on('data', function (data) {
     buffer += data.toString();
   });
-  
-  proc.stdout.on('end', function () {
-    
-    var items = []
-    ,   result = null
-    ,   lines = buffer.split('\n')
-    ,   lineNumber = 0
-    
-    for (var line in lines) {
-      lines[line] = lines[line].trim();
-      if (lines[line].length > 0) {
-        log(lines[line]);
-        if (lineNumber != 0) {
-           items.push(lines[line]);         
-        }
-        ++lineNumber;
-      }
-    }
-    
-    var item = items[0] || ''
-    ,   match = ITEM_PATTERN.exec(item)
-    ,   name
-    ,   type
-    ,   value
-    
-    if (match) {
-      name = match[1].trim();
-      type = match[2].trim();
-      value = match[3];
-      result = new RegistryItem(self.host, self.hive, self.key, name, type, value);
-    }
-    
-    cb(null, result);
-    
-  });
-  
+
   return this;
 };
 
@@ -392,20 +386,20 @@ Registry.prototype.get = function get (name, cb) {
  * put a value into this registry key, overwrites existing value
  */
 Registry.prototype.set = function set (name, type, value, cb) {
-  
+
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
+
   if (REG_TYPES.indexOf(type) == -1)
     throw Error('illegal type specified.');
-  
+
   var args = ['ADD', this.path, '/f', '/v', name, '/t', type, '/d', value]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
-  
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
@@ -414,12 +408,12 @@ Registry.prototype.set = function set (name, type, value, cb) {
       cb(null);
     }
   });
-  
+
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
   });
-  
+
   return this;
 };
 
@@ -427,17 +421,17 @@ Registry.prototype.set = function set (name, type, value, cb) {
  * remove a named value from this registry key
  */
 Registry.prototype.remove = function remove (name, cb) {
-  
+
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
+
   var args = name ? ['DELETE', this.path, '/f', '/v', name] : ['DELETE', this.path, '/f', '/ve']
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
-  
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
@@ -446,12 +440,12 @@ Registry.prototype.remove = function remove (name, cb) {
       cb(null);
     }
   });
-  
+
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
   });
-  
+
   return this;
 };
 
@@ -459,17 +453,17 @@ Registry.prototype.remove = function remove (name, cb) {
  * erase this registry key and it's contents
  */
 Registry.prototype.erase = function erase (cb) {
-  
+
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
+
   var args = ['DELETE', this.path, '/f', '/va']
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
-  
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
@@ -478,12 +472,12 @@ Registry.prototype.erase = function erase (cb) {
       cb(null);
     }
   });
-  
+
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
   });
-  
+
   return this;
 };
 
@@ -491,17 +485,17 @@ Registry.prototype.erase = function erase (cb) {
  * create this registry key
  */
 Registry.prototype.create = function create (cb) {
-  
+
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
+
   var args = ['ADD', this.path]
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
-  
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
@@ -510,12 +504,12 @@ Registry.prototype.create = function create (cb) {
       cb(null);
     }
   });
-  
+
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
   });
-  
+
   return this;
 };
 


### PR DESCRIPTION
Because both proc.on.close and stdin.on.end were called for each process
the return callback was fired twice.

Move all the parsing code to proc.on.close - so it works as desired.
