### PR TITLE
Accept empty names to set (Default) values to a registry key.

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -399,8 +399,15 @@ Registry.prototype.set = function set (name, type, value, cb) {
   if (REG_TYPES.indexOf(type) == -1)
     throw Error('illegal type specified.');
   
-  var args = ['ADD', this.path, '/f', '/v', name, '/t', type, '/d', value]
-  ,   proc = spawn('REG', args, {
+  var args = ['ADD', this.path];
+  if (name == '')
+    args.push('/ve');
+  else
+    args = args.concat(['/v', name]);
+  
+  args = args.concat(['/t', type, '/d', value, '/f']);
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]


### PR DESCRIPTION
From the help text `reg /?`

```
   /v       The value name, under the selected Key, to add.
  /ve      adds an empty value name (Default) for the key.
```
