### PR TITLE
Fix for Windows XP where REG QUERY returns with a header

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -358,7 +358,8 @@ Registry.prototype.get = function get (name, cb) {
         }
       }
 
-      var item = items[0] || ''
+      //Get last item - so it works in XP where REG QUERY returns with a header
+      var item = items[items.length-1] || ''
       ,   match = ITEM_PATTERN.exec(item)
       ,   name
       ,   type
@@ -392,13 +393,13 @@ Registry.prototype.set = function set (name, type, value, cb) {
 
   if (REG_TYPES.indexOf(type) == -1)
     throw Error('illegal type specified.');
-  
+
   var args = ['ADD', this.path];
   if (name == '')
     args.push('/ve');
   else
     args = args.concat(['/v', name]);
-  
+
   args = args.concat(['/t', type, '/d', value, '/f']);
 
   var proc = spawn('REG', args, {


### PR DESCRIPTION
- [x] @mikeyoon 
- [x] @fresc81 
- [x] @justinmchase

Older version os REG command return a header, so we need to skip it