### PR TITLE
Allow to get the default registry value.

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -328,8 +328,13 @@ Registry.prototype.get = function get (name, cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = [ 'QUERY', this.path, '/v', name ]
-  ,   proc = spawn('REG', args, {
+  var args = ['QUERY', this.path];
+  if (name == '')
+    args.push('/ve');
+  else
+    args = args.concat(['/v', name]);
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]


### PR DESCRIPTION
Using the `get` method to retrieve the default value of a registry key doesn't work. 
The default value should be queried using the `/ve` as opposed to the `/v`option that is used right now. 

Fixes #7 