### PR TITLE
Less restrictive item pattern as it is failing to match localized keys 

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -37,7 +37,7 @@ var util          = require('util')
 ,   PATH_PATTERN  = /^(HKEY_LOCAL_MACHINE|HKEY_CURRENT_USER|HKEY_CLASSES_ROOT|HKEY_USERS|HKEY_CURRENT_CONFIG)(.*)$/
 
 /* registry item pattern */
-,   ITEM_PATTERN  = /^([a-zA-Z0-9_\s\\-]+)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
+,   ITEM_PATTERN  = /^(.*)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
 
 
 


### PR DESCRIPTION
On windows, the key names are localized.

For example getting VLC registry values:

    HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432node\VideoLAN\VLC
        InstallDir    REG_SZ    C:\Program Files (x86)\VideoLAN\VLC
        Version    REG_SZ    2.1.5
        (par défaut)    REG_SZ    C:\Program Files (x86)\VideoLAN\VLC\vlc.exe
        Language    REG_SZ    1036

The `ITEM_PATTERN` needs to be more permissive.
