### PR TITLE
Add support for specifying 32 or 64 bit hive

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -89,12 +89,14 @@ function Registry (options) {
   ,   _host = '' + (_options.host || '')    // hostname
   ,   _hive = '' + (_options.hive || HKLM)  // registry hive
   ,   _key  = '' + (_options.key  || '')    // registry key
+  ,   _arch = _options.arch || null         // architecture (32 or 64 bit)
 
   /* getters/setters */
   this.__defineGetter__('host', function () { return _host; });
   this.__defineGetter__('hive', function () { return _hive; });
   this.__defineGetter__('key', function () { return _key; });
   this.__defineGetter__('path', function () { return (_host.length == 0 ? '' : '\\\\' + host + '\\') + _hive + _key; });
+  this.__defineGetter__('arch', function () { return _arch; });
   this.__defineGetter__('parent', function () {
     var i = _key.lastIndexOf('\\')
     return new Registry({
@@ -107,6 +109,9 @@ function Registry (options) {
   // validate options...
   if (HIVES.indexOf(_hive) == -1)
     throw new Error('illegal hive specified.');
+
+  if (_arch && _arch !== 64 && _arch !== 32)
+    throw new Error('illegal architecture specified (32 or 64).')
 
   if (!KEY_PATTERN.test(_key))
     throw new Error('illegal key specified.');
@@ -195,7 +200,12 @@ Registry.prototype.values = function values (cb) {
     throw new TypeError('must specify a callback');
 
   var args = [ 'QUERY', this.path ]
-  ,   proc = spawn('REG', args, {
+
+  if (this.arch) {
+    args.push('/reg:' + this.arch);
+  }
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
@@ -260,8 +270,13 @@ Registry.prototype.keys = function keys (cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = [ 'QUERY', this.path ]
-  ,   proc = spawn('REG', args, {
+  var args = [ 'QUERY', this.path ];
+
+  if (this.arch) {
+    args.push('/reg:' + this.arch);
+  }
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
@@ -328,8 +343,13 @@ Registry.prototype.get = function get (name, cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = [ 'QUERY', this.path, '/v', name ]
-  ,   proc = spawn('REG', args, {
+  var args = [ 'QUERY', this.path, '/v', name ];
+
+  if (this.arch) {
+    args.push('/reg:' + this.arch);
+  }
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
@@ -394,6 +414,11 @@ Registry.prototype.set = function set (name, type, value, cb) {
     throw Error('illegal type specified.');
   
   var args = ['ADD', this.path];
+
+  if (this.arch) {
+    args.push('/reg:' + this.arch);
+  }
+
   if (name == '')
     args.push('/ve');
   else
@@ -433,7 +458,12 @@ Registry.prototype.remove = function remove (name, cb) {
     throw new TypeError('must specify a callback');
 
   var args = name ? ['DELETE', this.path, '/f', '/v', name] : ['DELETE', this.path, '/f', '/ve']
-  ,   proc = spawn('REG', args, {
+
+  if (this.arch) {
+    args.push('/reg:' + this.arch);
+  }
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
@@ -464,8 +494,13 @@ Registry.prototype.erase = function erase (cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = ['DELETE', this.path, '/f', '/va']
-  ,   proc = spawn('REG', args, {
+  var args = ['DELETE', this.path, '/f', '/va'];
+
+  if (this.arch) {
+    args.push('/reg:' + this.arch);
+  }
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
@@ -496,8 +531,13 @@ Registry.prototype.create = function create (cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = ['ADD', this.path]
-  ,   proc = spawn('REG', args, {
+  var args = ['ADD', this.path];
+
+  if (this.arch) {
+    args.push('/reg:' + this.arch);
+  }
+
+  var proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]


### PR DESCRIPTION
- [ ] @mikeyoon 
- [ ] @fresc81 
- [ ] @justinmchase

Add the option to specify whether to use the 32-bit or 64-bit version of the registry (/reg argument). This is useful in node-webkit.