### PR TITLE
Extending the array prototype causes the library to crash

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -214,20 +214,20 @@ Registry.prototype.values = function values (cb) {
       ,   lines = buffer.split('\n')
       ,   lineNumber = 0
 
-      for (var line in lines) {
-        lines[line] = lines[line].trim();
-        if (lines[line].length > 0) {
-          log(lines[line]);
+      for (var i = 0, l = lines.length; i < l; i++) {
+        var line = lines[i].trim();
+        if (line.length > 0) {
+          log(line);
           if (lineNumber != 0) {
-            items.push(lines[line]);
+            items.push(line);
           }
           ++lineNumber;
         }
       }
 
-      for (var item in items) {
+      for (var i = 0, l = items.length; i < l; i++) {
 
-        var match = ITEM_PATTERN.exec(items[item])
+        var match = ITEM_PATTERN.exec(items[i])
         ,   name
         ,   type
         ,   value
@@ -286,17 +286,17 @@ Registry.prototype.keys = function keys (cb) {
     ,   result = []
     ,   lines = buffer.split('\n')
 
-    for (var line in lines) {
-      lines[line] = lines[line].trim();
-      if (lines[line].length > 0) {
-        log(lines[line]);
-        items.push(lines[line]);
+    for (var i = 0, l = lines.length; i < l; i++) {
+      var line = lines[i].trim();
+      if (line.length > 0) {
+        log(line);
+        items.push(line);
       }
     }
 
-    for (var item in items) {
+    for (var i = 0, l = items.length; i < l; i++) {
 
-      var match = PATH_PATTERN.exec(items[item])
+      var match = PATH_PATTERN.exec(items[i])
       ,   hive
       ,   key
 
@@ -347,12 +347,12 @@ Registry.prototype.get = function get (name, cb) {
       ,   lines = buffer.split('\n')
       ,   lineNumber = 0
 
-      for (var line in lines) {
-        lines[line] = lines[line].trim();
-        if (lines[line].length > 0) {
-          log(lines[line]);
+      for (var i = 0, l = lines.length; i < l; i++) {
+        var line = lines[i].trim();
+        if (line.length > 0) {
+          log(line);
           if (lineNumber != 0) {
-             items.push(lines[line]);
+             items.push(line);
           }
           ++lineNumber;
         }

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ r2
 .   keys(function (err, items) {
       
       if (!err)
-        for (var i in items)
+        for (var i = 0, l = items.length; i < l; i++)
           console.log('subkey of "'+r2.path+'": '+items[i].path);
       
       // list values

--- a/test.js
+++ b/test.js
@@ -1,4 +1,6 @@
 
+Array.prototype.someNewMethod = function() {};
+
 var Registry = require(__dirname+'/lib/registry.js')
 
 // create a registry client


### PR DESCRIPTION
- [ ] @mikeyoon 
- [x] @fresc81 
- [x] @justinmchase

I'm not sure if this repo is still maintained.

Nevertheless, we'd like to use the winreg library in our environment. In our code we are extending the Array prototype and adding some common methods. Unfortunately, this causes the winreg library to crash at lib/registry.js line 290, because the for ... in loops also include the added methods (no check for hasOwnProperty).

So I added this case to the test file and offered a solution for this issue. I'd be happy if you could accept this request.