### PR TITLE
Registry value names may have `.`s in them.

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -37,7 +37,7 @@ var util          = require('util')
 ,   PATH_PATTERN  = /^(HKEY_LOCAL_MACHINE|HKEY_CURRENT_USER|HKEY_CLASSES_ROOT|HKEY_USERS|HKEY_CURRENT_CONFIG)(.*)$/
 
 /* registry item pattern */
-,   ITEM_PATTERN  = /^([a-zA-Z0-9_\s\\-]+)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
+,   ITEM_PATTERN  = /^([a-zA-Z0-9_.\s\\-]+)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
 
 
 


### PR DESCRIPTION
Some registry keys have values with version numbers for names (e.g. 12.0).
Permit the `.` character in path names to support these keys.

fixes #19