### PR TITLE
Capture stdout/stderr and deliver inside error messages

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -40,6 +40,28 @@ var util          = require('util')
 ,   ITEM_PATTERN  = /^([a-zA-Z0-9_\s\\-]+)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
 
 
+/* Captures stdout/stderr for a child process */
+function captureOutput(child) {
+  // Use a mutable data structure so we can append as we get new data and have
+  // the calling context see the new data
+  var output = {'stdout': '', 'stderr': ''};
+
+  child.stdout.on('data', function(data) { output["stdout"] += data.toString(); });
+  child.stderr.on('data', function(data) { output["stderr"] += data.toString(); });
+
+  return output;
+}
+
+
+/* Returns an error message containing the stdout/stderr of the child process */
+function mkErrorMsg(registryCommand, code, output) {
+    var stdout = output['stdout'].trim();
+    var stderr = output['stderr'].trim();
+
+    var msg = util.format("%s command exited with code %d:\n%s\n%s", registryCommand, code, stdout, stderr);
+    return new Error(msg);
+}
+
 
 /**
  * a single registry value record
@@ -203,11 +225,13 @@ Registry.prototype.values = function values (cb) {
   ,   buffer = ''
   ,   self = this
 
+  var output = captureOutput(proc);
+
   proc.on('close', function (code) {
 
     if (code !== 0) {
       log('process exited with code ' + code);
-      cb(new Error('process exited with code ' + code), null);
+      cb(mkErrorMsg('QUERY', code, output), null);
     } else {
       var items = []
       ,   result = []
@@ -269,10 +293,12 @@ Registry.prototype.keys = function keys (cb) {
   ,   buffer = ''
   ,   self = this
 
+  var output = captureOutput(proc);
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
-      cb(new Error('process exited with code ' + code), null);
+      cb(mkErrorMsg('QUERY', code, output), null);
     }
   });
 
@@ -337,10 +363,12 @@ Registry.prototype.get = function get (name, cb) {
   ,   buffer = ''
   ,   self = this
 
+  var output = captureOutput(proc);
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
-      cb(new Error('process exited with code ' + code), null);
+      cb(mkErrorMsg('QUERY', code, output), null);
     } else {
       var items = []
       ,   result = null
@@ -407,10 +435,12 @@ Registry.prototype.set = function set (name, type, value, cb) {
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
 
+  var output = captureOutput(proc);
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
-      cb(new Error('process exited with code ' + code));
+      cb(mkErrorMsg('ADD', code, output, null));
     } else {
       cb(null);
     }
@@ -439,10 +469,12 @@ Registry.prototype.remove = function remove (name, cb) {
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
 
+  var output = captureOutput(proc);
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
-      cb(new Error('process exited with code ' + code));
+      cb(mkErrorMsg('DELETE', code, output), null);
     } else {
       cb(null);
     }
@@ -468,13 +500,14 @@ Registry.prototype.erase = function erase (cb) {
   ,   proc = spawn('REG', args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
+
+  var output = captureOutput(proc);
 
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
-      cb(new Error('process exited with code ' + code));
+      cb(mkErrorMsg("DELETE", code, output), null);
     } else {
       cb(null);
     }
@@ -503,10 +536,12 @@ Registry.prototype.create = function create (cb) {
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
 
+  var output = captureOutput(proc);
+
   proc.on('close', function (code) {
     if (code !== 0) {
       log('process exited with code ' + code);
-      cb(new Error('process exited with code ' + code));
+      cb(mkErrorMsg('ADD', code, output), null);
     } else {
       cb(null);
     }


### PR DESCRIPTION
- [x] @justinmchase
- [x] @mikeyoon 
- [x] @fresc81

This provides "useful" error messages instead of the thoroughly unhelpful "process exited with code 1"