### PR TITLE
Add error handler for all spawned processes

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -202,10 +202,12 @@ Registry.prototype.values = function values (cb) {
       })
   ,   buffer = ''
   ,   self = this
+  ,   error = null // null means no error previously reported.
 
   proc.on('close', function (code) {
-
-    if (code !== 0) {
+    if (error) {
+      return;
+    } else if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code), null);
     } else {
@@ -248,6 +250,11 @@ Registry.prototype.values = function values (cb) {
   proc.stdout.on('data', function (data) {
     buffer += data.toString();
   });
+  
+  proc.on('error', function(err) {
+    error = err;
+    cb(err);
+  });
 
   return this;
 };
@@ -268,9 +275,12 @@ Registry.prototype.keys = function keys (cb) {
       })
   ,   buffer = ''
   ,   self = this
+  ,   error = null // null means no error previously reported.
 
   proc.on('close', function (code) {
-    if (code !== 0) {
+    if (error) {
+      return;
+    } else if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code), null);
     }
@@ -316,6 +326,11 @@ Registry.prototype.keys = function keys (cb) {
     cb(null, result);
 
   });
+  
+  proc.on('error', function(err) {
+    error = err;
+    cb(err);
+  });
 
   return this;
 };
@@ -341,9 +356,12 @@ Registry.prototype.get = function get (name, cb) {
       })
   ,   buffer = ''
   ,   self = this
+  ,   error = null // null means no error previously reported.
 
   proc.on('close', function (code) {
-    if (code !== 0) {
+    if (error) {
+      return;
+    } else if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code), null);
     } else {
@@ -384,6 +402,11 @@ Registry.prototype.get = function get (name, cb) {
   proc.stdout.on('data', function (data) {
     buffer += data.toString();
   });
+  
+  proc.on('error', function(err) {
+    error = err;
+    cb(err);
+  });
 
   return this;
 };
@@ -412,9 +435,12 @@ Registry.prototype.set = function set (name, type, value, cb) {
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
+  ,   error = null // null means no error previously reported.
 
   proc.on('close', function (code) {
-    if (code !== 0) {
+    if(error) {
+      return;
+    } else if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code));
     } else {
@@ -425,6 +451,11 @@ Registry.prototype.set = function set (name, type, value, cb) {
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
+  });
+  
+  proc.on('error', function(err) {
+    error = err;
+    cb(err);
   });
 
   return this;
@@ -444,9 +475,12 @@ Registry.prototype.remove = function remove (name, cb) {
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
+  ,   error = null // null means no error previously reported.
 
   proc.on('close', function (code) {
-    if (code !== 0) {
+    if(error) {
+      return;
+    } else if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code));
     } else {
@@ -457,6 +491,11 @@ Registry.prototype.remove = function remove (name, cb) {
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
+  });
+  
+  proc.on('error', function(err) {
+    error = err;
+    cb(err);
   });
 
   return this;
@@ -476,9 +515,12 @@ Registry.prototype.erase = function erase (cb) {
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
+  ,   error = null // null means no error previously reported.
 
   proc.on('close', function (code) {
-    if (code !== 0) {
+    if(error) {
+      return;
+    } else if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code));
     } else {
@@ -489,6 +531,11 @@ Registry.prototype.erase = function erase (cb) {
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
+  });
+  
+  proc.on('error', function(err) {
+    error = err;
+    cb(err);
   });
 
   return this;
@@ -508,9 +555,12 @@ Registry.prototype.create = function create (cb) {
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'ignore' ]
       })
+  ,   error = null // null means no error previously reported.
 
   proc.on('close', function (code) {
-    if (code !== 0) {
+    if (error) {
+      return;
+    } else if (code !== 0) {
       log('process exited with code ' + code);
       cb(new Error('process exited with code ' + code));
     } else {
@@ -521,6 +571,11 @@ Registry.prototype.create = function create (cb) {
   proc.stdout.on('data', function (data) {
     // simply discard output
     log(''+data);
+  });
+  
+  proc.on('error', function(err) {
+    error = err;
+    cb(err);
   });
 
   return this;


### PR DESCRIPTION
Add .on('error') handler for all spawned processes.
They are required when the process cannot be spawned.
As the spawn is not sync, if the process cannot be created, the error is raised on process.nextTick.
If 'error' handler is missing, the error that is thrown on process.nextTick cannot be catched and the process crashes.
When error handler is added, the code can be try-catched.

In order to reproduce the issue, try using winreg on Linux or Mac.

Some info why error handler is required [here](https://github.com/nwjs/nw.js/issues/1623)