### PR TITLE
On Windows, always use reg.exe from System32 directory

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -7,6 +7,7 @@
 
 /* imports */
 var util          = require('util')
+,   path          = require('path')
 ,   spawn         = require('child_process').spawn
 
 /* set to console.log for debugging */
@@ -118,7 +119,17 @@ util.inherits(RegistryItem, Object);
 Object.freeze(RegistryItem);
 Object.freeze(RegistryItem.prototype);
 
-
+/**
+ * Get the path to system's reg.exe. Useful when another reg.exe is added to the PATH
+ * Implemented only for Windows
+ */
+function getRegExePath() {
+    if (process.platform === 'win32') {
+        return path.join(process.env.windir, 'system32', 'reg.exe');
+    } else {
+        return "REG";
+    }
+}
 
 /**
  * a registry object, which provides access to a single Registry key
@@ -248,7 +259,7 @@ Registry.prototype.values = function values (cb) {
 
   pushArch(args, this.arch);
 
-  var proc = spawn('REG', args, {
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'pipe' ]
@@ -326,7 +337,7 @@ Registry.prototype.keys = function keys (cb) {
 
   pushArch(args, this.arch);
 
-  var proc = spawn('REG', args, {
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'pipe' ]
@@ -412,7 +423,7 @@ Registry.prototype.get = function get (name, cb) {
 
   pushArch(args, this.arch);
 
-  var proc = spawn('REG', args, {
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'pipe' ]
@@ -497,7 +508,7 @@ Registry.prototype.set = function set (name, type, value, cb) {
 
   pushArch(args, this.arch);
 
-  var proc = spawn('REG', args, {
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'pipe' ]
@@ -542,7 +553,7 @@ Registry.prototype.remove = function remove (name, cb) {
 
   pushArch(args, this.arch);
 
-  var proc = spawn('REG', args, {
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'pipe' ]
@@ -587,7 +598,7 @@ Registry.prototype.erase = function erase (cb) {
 
   pushArch(args, this.arch);
 
-  var proc = spawn('REG', args, {
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
       })
@@ -631,7 +642,7 @@ Registry.prototype.create = function create (cb) {
 
   pushArch(args, this.arch);
 
-  var proc = spawn('REG', args, {
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'pipe' ]


### PR DESCRIPTION
 - [x] @fresc81
 - [x] @justinmchase
 - [x] @mikeyoon

See https://github.com/fresc81/node-winreg/issues/17