### PR TITLE
Actually delete key when calling erase()

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -756,7 +756,7 @@ Registry.prototype.erase = function erase (cb) {
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
 
-  var args = ['DELETE', this.path, '/f', '/va'];
+  var args = ['DELETE', this.path, '/f'];
 
   pushArch(args, this.arch);
 


### PR DESCRIPTION
Fixes #4. Supersedes #22 and merges cleanly.