### PR TITLE
Fix destroy() method errors

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -813,21 +813,26 @@ Registry.prototype.destroy = function destroy (cb) {
   
   if (typeof cb !== 'function')
     throw new TypeError('must specify a callback');
-  
-  var args = ['DELETE', this.path, '/f']
-  , proc = spawn('REG', args, {
+
+  var args = ['DELETE', this.path, '/f'];
+
+  pushArch(args, this.arch);
+
+  var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
         stdio: [ 'ignore', 'pipe', 'pipe' ]
       })
   ,   error = null // null means no error previously reported.
-  
+
+  var output = captureOutput(proc);
+
   proc.on('close', function (code) {
-    if(error) {
+    if (error) {
       return;
     } else if (code !== 0) {
       log('process exited with code ' + code);
-      cb(mkErrorMsg("DELETE", code, output), null);
+      cb(mkErrorMsg('DELETE', code, output), null);
     } else {
       cb(null);
     }


### PR DESCRIPTION
Noticed that the `destroy()` method will actually throw an exception because `output` is not defined. There were also several other inconsistencies with the other methods.

Can this be released to npm?