### PR TITLE
Make "silent" apps possible

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -443,7 +443,8 @@ Registry.prototype.values = function values (cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   buffer = ''
   ,   self = this
@@ -525,7 +526,8 @@ Registry.prototype.keys = function keys (cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   buffer = ''
   ,   self = this
@@ -616,7 +618,8 @@ Registry.prototype.get = function get (name, cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   buffer = ''
   ,   self = this
@@ -707,7 +710,8 @@ Registry.prototype.set = function set (name, type, value, cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   error = null // null means no error previously reported.
 
@@ -757,7 +761,8 @@ Registry.prototype.remove = function remove (name, cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   error = null // null means no error previously reported.
 
@@ -805,7 +810,8 @@ Registry.prototype.clear = function clear (cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   error = null // null means no error previously reported.
 
@@ -863,7 +869,8 @@ Registry.prototype.destroy = function destroy (cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   error = null // null means no error previously reported.
 
@@ -911,7 +918,8 @@ Registry.prototype.create = function create (cb) {
   var proc = spawn(getRegExePath(), args, {
         cwd: undefined,
         env: process.env,
-        stdio: [ 'ignore', 'pipe', 'pipe' ]
+        stdio: [ 'ignore', 'pipe', 'pipe' ],
+        windowsHide: true,
       })
   ,   error = null // null means no error previously reported.
 


### PR DESCRIPTION
Without `windowsHide: true`, command prompts will pop up on every call to this library - which is obviously a major UX problem with apps that don't run on the command line.

And at least as far as I'm aware, aside from that, there really isn't any difference when setting this to `true`.