### PR TITLE
Path arg fix

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -294,7 +294,7 @@ function Registry (options) {
    * @readonly
    * @member {string} Registry#path
    */
-  this.__defineGetter__('path', function () { return (_host.length == 0 ? '' : '\\\\' + _host + '\\') + _hive + _key; });
+  this.__defineGetter__('path', function () { return '"' + (_host.length == 0 ? '' : '\\\\' + _host + '\\') + _hive + _key + '"'; });
 
   /**
    * The registry hive architecture ('x86' or 'x64').


### PR DESCRIPTION
When the path of the registry key is passed down to reg.exe in the child_process.spawn() arguments, if the registry key has spaces in it's path then it will error out. This fixes that by wrapping the path in quotes.