### PR TITLE
Check if process.env.windir is defined

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -140,7 +140,7 @@ function pushArch(args, arch) {
  * Implemented only for Windows
  */
 function getRegExePath() {
-    if (process.platform === 'win32') {
+    if (process.platform === 'win32' && process.env.windir !== undefined) {
         return path.join(process.env.windir, 'system32', 'reg.exe');
     } else {
         return "REG";


### PR DESCRIPTION
path.join will throw an error if undefined.
Even though platform is win32, process.env.windir may be undefined.

In this case the library should fallback to the path reg, one could add more fallback options like %systemroot%.
But falling back to path is definitly better than failing.

I came upon this issue using winreg in electron 29.1.1

`TypeError: The "path" argument must be of type string. Received undefined
    at __node_internal_captureLargerStackTrace (node:internal/errors:497:5)
    at new NodeError (node:internal/errors:406:5)
    at validateString (node:internal/validators:162:11)
    at Object.join (node:path:433:7)
    at xs (index-2b4f9e2c.js:51:251)
    at ht.values (index-2b4f9e2c.js:51:1965)
    at ht.keyExists (index-2b4f9e2c.js:54:2663)`

`function xs() {
    return process.platform === "win32" ? a5.join({}.windir, "system32", "reg.exe") : "REG"
}`

